### PR TITLE
added environment variable RSIM_SILENT_DEBUG to suppress rocketsim ou…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,13 +3,18 @@ use glob::glob;
 use miette::{IntoDiagnostic, Result};
 
 fn main() -> Result<()> {
+    println!("cargo:rerun-if-env-changed=RSIM_SILENT_DEBUG");
     let mut builder = Builder::new("src/lib.rs", ["RocketSim/src/", "arenar/"])
         .extra_clang_args(&["-std=c++20"])
         .build()?;
 
-    if !cfg!(debug_assertions) {
+    if cfg!(debug_assertions) && std::env::var("RSIM_SILENT_DEBUG").is_ok_and(|x| x != "0"){
+        builder.define("RS_DONT_LOG", "1");
+    }
+    else if !cfg!(debug_assertions) {
         builder.define("RS_DONT_LOG", "1").define("RS_MAX_SPEED", "1");
     }
+   
 
     builder
         .use_plt(false)


### PR DESCRIPTION
…tput even in debug mode

tests all passed. I tested a few builds with and without with the new environment variable and it works as expected.