### PR TITLE
swapped the silent rocketsim from an env variable to a feature (silen…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ lto = true
 default = []
 glam = ["dep:glam"]
 bin = []
+silent_rsim = []
 
 [target.'cfg(not(any(target_arch = "x86", target_arch = "x86_64")))'.dependencies]
 # use glam with experimental support for portable SIMD when not running on x86

--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,13 @@
 use autocxx_build::Builder;
 use glob::glob;
 use miette::{IntoDiagnostic, Result};
-use std::env;
 
 fn main() -> Result<()> {
-    println!("cargo:rerun-if-env-changed=RSIM_SILENT_DEBUG");
     let mut builder = Builder::new("src/lib.rs", ["RocketSim/src/", "arenar/"])
         .extra_clang_args(&["-std=c++20"])
         .build()?;
 
-    if !cfg!(debug_assertions) || env::var("RSIM_SILENT_DEBUG").is_ok_and(|x| x != "0") {
+    if cfg!(feature = "silent_rsim") {
         builder.define("RS_DONT_LOG", "1");
     }
 


### PR DESCRIPTION
…t_rsim). If I enable the feature in either my crate or my dependency between us, it's quiet. If I don't enable it in either, it's like normal.