### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -47,6 +47,9 @@ jobs:
           done
       - name: Get cached dependencies
         uses: Swatinem/rust-cache@v2
+      - name: Update libclang (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install libclang-dev
       - name: Build project (Windows)
         if: matrix.os == 'windows-latest'
         shell: cmd

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -49,9 +49,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Update libclang (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt remove libclang-dev -y
-          sudo apt install libclang-16-dev -y
+        run: sudo apt install libclang-16-dev -y
       - name: Build project (Windows)
         if: matrix.os == 'windows-latest'
         shell: cmd

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -49,7 +49,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Update libclang (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install libclang-dev
+        run: |
+          sudo apt remove libclang-dev -y
+          sudo apt install libclang-16-dev -y
       - name: Build project (Windows)
         if: matrix.os == 'windows-latest'
         shell: cmd

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Update libclang (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install libclang-16-dev -y
+        run: sudo apt install libclang-15-dev -y
       - name: Build project (Windows)
         if: matrix.os == 'windows-latest'
         shell: cmd

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-24.04, macos-latest]
         features: [ all, no, default ]
         include:
           - os: windows-latest

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
         include:
           - os: windows-latest
           - os: macos-latest
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
           - features: all
             features_arg: --all-features
           - features: no
@@ -47,9 +47,6 @@ jobs:
           done
       - name: Get cached dependencies
         uses: Swatinem/rust-cache@v2
-      - name: Update libclang (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install libclang-15-dev -y
       - name: Build project (Windows)
         if: matrix.os == 'windows-latest'
         shell: cmd

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,7 +25,7 @@ jobs:
           - features: default
             features_arg:
 
-    name: ${{ matrix.os }}, ${{ matrix.toolchain }} toolchain, ${{ matrix.features }} features
+    name: ${{ matrix.os }}, nightly, ${{ matrix.features }} features
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
@@ -47,7 +47,15 @@ jobs:
           done
       - name: Get cached dependencies
         uses: Swatinem/rust-cache@v2
+      - name: Build project (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: |
+          set PATH=%PATH:C:\Program Files\LLVM\bin;=%
+          cargo build ${{ matrix.features_arg }}
       - name: Build project
+        if: matrix.os != 'windows-latest'
         run: cargo build ${{ matrix.features_arg }}
       - name: Run tests
+        if: matrix.os != 'windows-latest'
         run: cargo test ${{ matrix.features_arg }}


### PR DESCRIPTION
Fix Windows by adding `set PATH=%PATH:C:\Program Files\LLVM\bin;=%` before building
Fix Linux by using `ubuntu-24.04` (`ubuntu-latest` uses `ubuntu-22.04` which uses a version of libclang that's too old for c++20 features)